### PR TITLE
Quickfix: Add LEFT JOIN

### DIFF
--- a/src/database/queries/accounts/getCurrentBalance.sql
+++ b/src/database/queries/accounts/getCurrentBalance.sql
@@ -1,8 +1,8 @@
 SELECT
-    IFNULL(SUM(amount), 0) + a.start_balance AS 'currentBalance'
+    IFNULL(SUM(t.amount), 0) + a.start_balance AS 'currentBalance'
 FROM
     accounts AS a
-    JOIN transactions AS t ON t.account_id = a.id
+    LEFT JOIN transactions AS t ON t.account_id = a.id
 WHERE
     a.id = ?
 GROUP BY


### PR DESCRIPTION
Bug: Account.getCurrentBalance() would not return value for accounts without transactions.  This PR fixes that bug.